### PR TITLE
Add default option to daterangePicker

### DIFF
--- a/R/shinyExtInput.R
+++ b/R/shinyExtInput.R
@@ -57,6 +57,7 @@ actionButton <- function(inputId, label) {
 #'  value.
 #' @param label The contents of the button--usually a text label, but you could
 #'   also use any other HTML, like an image.
+#' @param default Specify a default input value as a character vector.
 #'   
 #' @export
 daterangePicker <- function(inputId, label, default="") {

--- a/R/shinyExtInput.R
+++ b/R/shinyExtInput.R
@@ -59,7 +59,7 @@ actionButton <- function(inputId, label) {
 #'   also use any other HTML, like an image.
 #'   
 #' @export
-daterangePicker <- function(inputId, label) {
+daterangePicker <- function(inputId, label, default="") {
   addResourcePath(
     prefix='shinyExt', 
     directoryPath=system.file('inputExt', 
@@ -72,7 +72,7 @@ daterangePicker <- function(inputId, label) {
                                   href = 'shinyExt/css/daterangepicker.css'),
                         tags$script(src = 'shinyExt/js/jquery-common.js'))),
     tags$label(label),
-    tags$input(id = inputId, type="text", value="", name ="daterange-picker")
+    tags$input(id = inputId, type="text", value=default, name ="daterange-picker")
   )
 }
 


### PR DESCRIPTION
This allows for display of instruction text (or default values) in the Bootstrap date picker.

![temp](https://f.cloud.github.com/assets/535969/199570/5c7d21c2-808d-11e2-92ff-b15c18d0a68c.png)
